### PR TITLE
Add CircleCI, with scheduled builds to keep the free JFrog repo active

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+# Scala CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/sample-config/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
+
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      JVM_OPTS: -Xmx3200m
+      TERM: dumb
+
+    steps:
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "build.sbt" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      - run: cat /dev/null | sbt test:compile
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v1-dependencies--{{ checksum "build.sbt" }}
+
+      # run tests!
+      - run: cat /dev/null | sbt test:test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build-and-publish:
+  build:
     docker:
       - image: hseeberger/scala-sbt:8u151-2.12.5-1.1.2
 
@@ -14,14 +14,25 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - scala-utils-dependencies-
 
-      - run: cat /dev/null | sbt test:compile
+      - run: sbt compile package
 
       - save_cache:
           paths:
             - ~/.m2
           key: scala-utils-dependencies-{{ checksum "build.sbt" }}
 
-      - run: sbt clean compile package publish
+  publish:
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - scala-utils-dependencies-{{ checksum "build.sbt" }}
+            # fallback to using the latest cache if no exact match is found
+            - scala-utils-dependencies-
+
+      - run: sbt compile package publish
+
 
 workflows:
   version: 2
@@ -29,10 +40,18 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "43 2 * * 4"
+          cron: "51 2 * * 4"
           filters:
             branches:
               only:
                 - circleci-project-setup
     jobs:
-      - build-and-publish
+      - build
+      - publish:
+          depends_on:
+            - build
+          filters:
+            branches:
+              only:
+                - circleci-project-setup
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             - scala-utils-dependencies-
 
       - run: |
-          echo $JFROG_CREDENTIALS > credentials.properties
+          echo "${JFROG_CREDENTIALS}" > credentials.properties
           sbt compile package publish
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,11 +47,11 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "36 3 * * 1,4"
+          cron: "40 3 * * 1,4"
           filters:
             branches:
               only:
-                - circleci-project-setup
+                - master
     jobs:
       - build
       - publish:
@@ -60,7 +60,7 @@ workflows:
           filters:
             branches:
               only:
-                - circleci-project-setup
+                - master
 
   integration:
     jobs:
@@ -71,5 +71,5 @@ workflows:
           filters:
             branches:
               only:
-                - circleci-project-setup
+                - master
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,9 @@ jobs:
           key: scala-utils-dependencies-{{ checksum "build.sbt" }}
 
   publish:
+    docker:
+      - image: hseeberger/scala-sbt:8u151-2.12.5-1.1.2
+
     steps:
       - checkout
 
@@ -40,7 +43,7 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "53 2 * * 4"
+          cron: "56 2 * * 4"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,8 @@
-# Scala CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/sample-config/ for more details
-#
 version: 2
 jobs:
-  build:
+  build-and-publish:
     docker:
-      # specify the version you desire here
-      - image: circleci/openjdk:8-jdk
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
-
-    working_directory: ~/repo
-
-    environment:
-      # Customize the JVM maximum heap limit
-      JVM_OPTS: -Xmx3200m
-      TERM: dumb
+      - image: hseeberger/scala-sbt:8u151-2.12.5-1.1.2
 
     steps:
       - checkout
@@ -27,16 +10,28 @@ jobs:
       # Download and cache dependencies
       - restore_cache:
           keys:
-            - v1-dependencies-{{ checksum "build.sbt" }}
+            - scala-utils-dependencies-{{ checksum "build.sbt" }}
             # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
+            - scala-utils-dependencies-
 
       - run: cat /dev/null | sbt test:compile
 
       - save_cache:
           paths:
             - ~/.m2
-          key: v1-dependencies--{{ checksum "build.sbt" }}
+          key: scala-utils-dependencies-{{ checksum "build.sbt" }}
 
-      # run tests!
-      - run: cat /dev/null | sbt test:test
+      - run: sbt clean compile package publish
+
+workflows:
+  daily-build:
+    # Make sure we keep our free JFrog repository active :)
+    triggers:
+      - schedule:
+          cron: "43 2 * * 4"
+          filters:
+            branches:
+              only:
+                - circleci-project-setup
+    jobs:
+      - build-and-publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,7 @@ jobs:
       - run: sbt clean compile package publish
 
 workflows:
+  version: 2
   daily-build:
     # Make sure we keep our free JFrog repository active :)
     triggers:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,10 @@ jobs:
             - scala-utils-dependencies-
 
       - run:
-        name: "Publish!"
-        command: |
-          echo "${JFROG_CREDENTIALS}" > credentials.properties
-          sbt compile package publish
+          name: "Publish!"
+          command: |
+            echo "${JFROG_CREDENTIALS}" > credentials.properties
+            sbt compile package publish
 
 
 workflows:
@@ -47,7 +47,7 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "13 3 * * 4"
+          cron: "16 3 * * 4"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "51 2 * * 4"
+          cron: "53 2 * * 4"
           filters:
             branches:
               only:
@@ -48,7 +48,7 @@ workflows:
     jobs:
       - build
       - publish:
-          depends_on:
+          requires:
             - build
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: "Publish!"
           command: |
-            echo "${JFROG_CREDENTIALS}" | base64 -d -o credentials.properties
+            echo "${JFROG_CREDENTIALS}" | base64 -d > credentials.properties
             sbt compile package publish
 
 
@@ -47,7 +47,7 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "23 3 * * 4"
+          cron: "27 3 * * 4"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: "Publish!"
           command: |
-            echo "${JFROG_CREDENTIALS}" > credentials.properties
+            echo "${JFROG_CREDENTIALS}" | base64 -d -o credentials.properties
             sbt compile package publish
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "16 3 * * 4"
+          cron: "23 3 * * 4"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "56 2 * * 4"
+          cron: "6 3 * * 4"
           filters:
             branches:
               only:
@@ -63,4 +63,11 @@ workflows:
   integration:
     jobs:
       - build
+      - publish:
+          requires:
+            - build
+          filters:
+            branches:
+              only:
+                - circleci-project-setup
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,3 +55,7 @@ workflows:
               only:
                 - circleci-project-setup
 
+  integration:
+    jobs:
+      - build
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "27 3 * * 4"
+          cron: "36 3 * * 1,4"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "40 3 * * 1,4"
+          cron: "0 20 * * 1,4"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - scala-utils-dependencies-
 
-      - run: |
+      - run:
+        name: "Publish!"
+        command: |
           echo "${JFROG_CREDENTIALS}" > credentials.properties
           sbt compile package publish
 
@@ -45,7 +47,7 @@ workflows:
     # Make sure we keep our free JFrog repository active :)
     triggers:
       - schedule:
-          cron: "6 3 * * 4"
+          cron: "13 3 * * 4"
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,9 @@ jobs:
             # fallback to using the latest cache if no exact match is found
             - scala-utils-dependencies-
 
-      - run: sbt compile package publish
+      - run: |
+          echo $JFROG_CREDENTIALS > credentials.properties
+          sbt compile package publish
 
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ If you found a bug in the source code or if you want to contribute with new feat
 
 ### Publish
 
-Create a `credentials.properties` file in the project's directory, with [the content you can find here])https://vault.grupozap.io/ui/vault/secrets/squad-listings/show/servicos/jfrog-quality), and run:
+Once you merge your code to the master branch, [CircleCI](https://app.circleci.com/pipelines/github/olxbr/scala-utils) should automatically publish it.
+
+To publish manually, create a `credentials.properties` file in the project's directory, with [the content you can find here])https://vault.grupozap.io/ui/vault/secrets/squad-listings/show/servicos/jfrog-quality), and run:
 ```shell
 sbt clean compile package publish
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -30,6 +30,7 @@ developers ++= List(
 
 pomIncludeRepository := (_ => false)
 
+publishConfiguration := publishConfiguration.value.withOverwrite(true)
 publishTo := Some("Artifactory Realm" at "https://squadzapquality.jfrog.io/artifactory/olxbr-sbt-release")
 credentials += Credentials(new File("credentials.properties"))
 


### PR DESCRIPTION
Add CircleCI configuration, with jobs to `build` and to `publish` the artifact.

Besides running on `push`, it will also run **every Monday and Thursday** at 5pm (BRT), to make sure our free JFrog repository is not deleted by inactivity.